### PR TITLE
Fix template attempting to use <video> to display jpg from last commit

### DIFF
--- a/site/content/entry/yuzu-progress-report-2018-p1-1/index.md
+++ b/site/content/entry/yuzu-progress-report-2018-p1-1/index.md
@@ -30,9 +30,9 @@ of an emulator for Switch. Using the available documentation, [bunnei](https://g
 worked on yuzu privately for a few months before other Citra developers joined him. They made some
 progress and finally went public on 14 January, 2018.
 
-{{< gifv
+{{< imgs
 	  "/images/entry/yuzu-progress-report-2018-p1/homebrew.mp4|Before (Colors are wrong)"
-    "/images/entry/yuzu-progress-report-2018-p1/homebrew_work.jpg|After (fixed)"
+	  "/images/entry/yuzu-progress-report-2018-p1/homebrew_work.jpg|After (fixed)"
 >}}
 
 {{< imgs


### PR DESCRIPTION
This uses the type auto-detection added to shared-bulma-theme.