### PR TITLE
Add Patreon link

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -37,6 +37,12 @@ paginate = 20
   identifier = "donate"
   url = "/donate"
 
+[[menu.main]]
+  name = "patreon"
+  weight = 5
+  identifier = "patreon"
+  url = "https://www.patreon.com/yuzuteam"
+
 [Params]
   Tenant = "yuzu"
   BulmaPrimaryShade = "is-dark"


### PR DESCRIPTION
This adds a Patreon link to the navbar.

Decision was made to leave current donation page as-is for now.
