### PR TITLE
Fix backgrounds of pre-wrapped code

### DIFF
--- a/src/scss/yuzu/yuzu.scss
+++ b/src/scss/yuzu/yuzu.scss
@@ -93,6 +93,6 @@ a:hover {
 }
 
 // Fix background color of monospaced text
-.content code {
+.content :not(pre) > code {
   background: $dark;
 }


### PR DESCRIPTION
This fixes a previously introduced bug where styling was incorrectly applied to blocks of code (wrapped in `<pre>` tags).

Fixed styling (rest of document has broken markup, but not due to this PR):

![capture](https://user-images.githubusercontent.com/1404334/45280358-5cc3a100-b517-11e8-9534-9de00c86a8d7.PNG)
