### PR TITLE
Don't open a new tab when the download button is clicked (Take 2)

### DIFF
--- a/site/layouts/partials/homepage/heroContents.html
+++ b/site/layouts/partials/homepage/heroContents.html
@@ -7,7 +7,7 @@
             <p>It is written in C++ with portability in mind, with builds actively maintained for Windows, Linux and macOS.</p>
         </div>
         <div>
-            <a class="button mr-sm is-medium is-light is-hidden-touch" href="/downloads" target="_blank">
+            <a class="button mr-sm is-medium is-light is-hidden-touch" href="/downloads">
                 <span class="icon">
                     <i class="fas fa-arrow-down"></i>
                 </span>


### PR DESCRIPTION
When the download button in the middle of the homepage is clicked, a new tab won't be opened now.

This behavior pissed me off so hard, that I had to make a PR for it :P