### PR TITLE
Update to yuzu_copy.bat to account for nand ID

### DIFF
--- a/site/content/help/quickstart/yuzu_copy.bat
+++ b/site/content/help/quickstart/yuzu_copy.bat
@@ -4,6 +4,28 @@ TITLE Yuzu Copy Utility v2
 ECHO Yuzu Copy Utility v2
 ECHO     By DarkLordZach
 ECHO 
+
+SET mypath=%~dp0\backup\
+cd /d %mypath%
+if exist dumps goto noid
+if not exist dumps goto id
+
+:id
+for /d %%A in (*) do cd %%A
+ECHO Copying fuses...
+COPY /B /Y "dumps\fuses.bin" "%APPDATA%\yuzu\sysdata\fuses.bin"
+ECHO Copying BOOT0...
+COPY /B /Y "BOOT0" "%APPDATA%\yuzu\sysdata\BOOT0"
+ECHO Copying package1...
+COPY /B /Y "pkg1\secmon.bin" "%APPDATA%\yuzu\sysdata\secmon.bin"
+COPY /B /Y "pkg1\pkg1_decr.bin" "%APPDATA%\yuzu\sysdata\pkg1_decr.bin"
+ECHO Copying NAND backup...
+COPY /B /Y "%~dp0\rawnand.bin.00"+"%~dp0\rawnand.bin.01"+"%~dp0\rawnand.bin.02"+"%~dp0\rawnand.bin.03"+"%~dp0\rawnand.bin.04"+"%~dp0\rawnand.bin.05"+"%~dp0\rawnand.bin.06"+"%~dp0\rawnand.bin.07"+"%~dp0\rawnand.bin.08"+"%~dp0\rawnand.bin.09"+"%~dp0\rawnand.bin.10"+"%~dp0\rawnand.bin.11"+"%~dp0\rawnand.bin.12"+"%~dp0\rawnand.bin.13"+"%~dp0\rawnand.bin.14" "%USERPROFILE%\Desktop\rawnand.bin"
+ECHO If no errors about missing files appeared, this utility completed successfully.
+ECHO If there were errors, ensure you followed all of the steps in the guide prior to this.
+goto exit
+
+:noid
 ECHO Copying fuses...
 COPY /B /Y "%~dp0\backup\dumps\fuses.bin" "%APPDATA%\yuzu\sysdata\fuses.bin"
 ECHO Copying BOOT0...
@@ -13,8 +35,9 @@ COPY /B /Y "%~dp0\backup\pkg1\secmon.bin" "%APPDATA%\yuzu\sysdata\secmon.bin"
 COPY /B /Y "%~dp0\backup\pkg1\pkg1_decr.bin" "%APPDATA%\yuzu\sysdata\pkg1_decr.bin"
 ECHO Copying NAND backup...
 COPY /B /Y "%~dp0\rawnand.bin.00"+"%~dp0\rawnand.bin.01"+"%~dp0\rawnand.bin.02"+"%~dp0\rawnand.bin.03"+"%~dp0\rawnand.bin.04"+"%~dp0\rawnand.bin.05"+"%~dp0\rawnand.bin.06"+"%~dp0\rawnand.bin.07"+"%~dp0\rawnand.bin.08"+"%~dp0\rawnand.bin.09"+"%~dp0\rawnand.bin.10"+"%~dp0\rawnand.bin.11"+"%~dp0\rawnand.bin.12"+"%~dp0\rawnand.bin.13"+"%~dp0\rawnand.bin.14" "%USERPROFILE%\Desktop\rawnand.bin"
-
 ECHO If no errors about missing files appeared, this utility completed successfully.
 ECHO If there were errors, ensure you followed all of the steps in the guide prior to this.
+goto exit
 
+:exit
 PAUSE


### PR DESCRIPTION
Leaves the original content of the .bat untouched, but ads a few variables to check to see if the folder after `backup` is the backed up contents and if not, to `cd` that folder and treat the contents essentially the same as the original bat.