### PR TITLE
Adding info concerning key length

### DIFF
--- a/site/content/help/quickstart/console.keys
+++ b/site/content/help/quickstart/console.keys
@@ -2,6 +2,8 @@
 ## yuzu assumes that you also have BOOT0, PRODINFO, BCPKG2, fuses, and needed system saves (43, E1, E2).
 ## If you don't have all of those components in sysdata, you will need additional keys.
 ## Refer to the dumping guide for more details -- you might have missed a step!
+## Each Key is 32 digits in length. If they are 64 digits, then the first 32 are crypt and second 32 are tweak.
+## BIS key 2 and 3 are the same. If they are not, please write down BIS Key 3 as well. 
 
 # Falcon Keys
 tsec_key        = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
The latest BISKey dump combines both crypt and tweak into one line. Changes clarify which key is which and if the last BIS Key, 3, is needed to be copied as well.