### PR TITLE
Update yuzu_copy.bat

### DIFF
--- a/site/content/help/quickstart/yuzu_copy.bat
+++ b/site/content/help/quickstart/yuzu_copy.bat
@@ -24,7 +24,7 @@ COPY /B /Y "pkg1\secmon.bin" "%APPDATA%\yuzu\sysdata\secmon.bin"
 COPY /B /Y "pkg1\pkg1_decr.bin" "%APPDATA%\yuzu\sysdata\pkg1_decr.bin"
 if exist "%~dp0\rawnand.bin.00" (
 ECHO Copying NAND backup...
-COPY /B /Y "%~dp0\rawnand.bin.00"+"%~dp0\rawnand.bin.01"+"%~dp0\rawnand.bin.02"+"%~dp0\rawnand.bin.03"+"%~dp0\rawnand.bin.04"+"%~dp0\rawnand.bin.05"+"%~dp0\rawnand.bin.06"+"%~dp0\rawnand.bin.07"+"%~dp0\rawnand.bin.08"+"%~dp0\rawnand.bin.09"+"%~dp0\rawnand.bin.10"+"%~dp0\rawnand.bin.11"+"%~dp0\rawnand.bin.12"+"%~dp0\rawnand.bin.13"+"%~dp0\rawnand.bin.14" "%USERPROFILE%\Desktop\rawnand.bin"
+COPY /B /Y "rawnand.bin.00"+"rawnand.bin.01"+"rawnand.bin.02"+"rawnand.bin.03"+"rawnand.bin.04"+"rawnand.bin.05"+"rawnand.bin.06"+"rawnand.bin.07"+"rawnand.bin.08"+"rawnand.bin.09"+"rawnand.bin.10"+"rawnand.bin.11"+"rawnand.bin.12"+"rawnand.bin.13"+"rawnand.bin.14" "%USERPROFILE%\Desktop\rawnand.bin"
 ECHO **Your rawnand.bin files have been combined into one rawnand.bin onto your desktop.**
 )
 ECHO **If no errors about missing files appeared, this utility completed successfully. Please continue with QuickStart guide.**


### PR DESCRIPTION
Seems that if NAND ID is used by Hekate, then the rawnand.bin is now dumped in sections there. Updated to remove wrong file pathing.