### PR TITLE
Only show .zip windows release

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -34,10 +34,8 @@ function releaseCallback(v, count, e) {
         var release_commit_url = `https://github.com/yuzu-emu/yuzu-${v}/commit/${release_commit}`;
 
         var release_title = '';
-        if (v == 'nightly') {
-            release_title = 'Nightly Build';
-        } else if (v == 'canary') {
-            release_title = 'Canary Build';
+        if (v == 'mainline') {
+            release_title = 'Mainline Build';
         }
 
         if (release_commit) {
@@ -50,6 +48,8 @@ function releaseCallback(v, count, e) {
             if (asset.name.includes('nupkg')) return;
             if (asset.name.includes('.7z')) return;
             if (asset.name.includes('RELEASES')) return;
+            if (asset.name.includes('.tar.xz') && (asset.name.includes('windows'))) return;
+            if (asset.name.includes('-debugsymbols.zip')) return;
 
             /* We only want to provide the msvc builds on the downloads page for Windows. */
             if (asset.name.includes('-mingw-')) return;


### PR DESCRIPTION
Multiple users have brought up the fact that it's confusing when trying to manually download a Windows release because there are 3 or 4 available. Updated the download script to reject any windows builds besides the standard .zip release.