### PR TITLE
Rename package listing button

### DIFF
--- a/site/layouts/page/downloads.html
+++ b/site/layouts/page/downloads.html
@@ -69,7 +69,7 @@
                 </a>
                 -->
                 <a class="button" id="view-package-listing-button">
-                    View package listing
+                    Manual Download
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Users have reported that the "view package listing" button is confusing
Renaming the button to "Manual Download" to mirror Citra