### PR TITLE
Update <code> tag style

### DIFF
--- a/src/scss/yuzu/yuzu.scss
+++ b/src/scss/yuzu/yuzu.scss
@@ -94,7 +94,17 @@ a:hover {
 
 // Fix background color of monospaced text
 .content :not(pre) > code {
-  background: $dark;
+  background: #101010;
+}
+
+code {
+  color: #FFFFFF;
+  font-size: 0.875em;
+  font-weight: 400;
+  padding: 0.15em 0.25em 0.15em 0.25em;
+  border: 1px solid #585d66;
+  border-radius: 4px;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.125);
 }
 
 // Workaround for browsers without JavaScript for the downloads page


### PR DESCRIPTION
Updates the `<code>` tag style as inspired by other modern styles.

Before:
![image](https://user-images.githubusercontent.com/52414509/102742101-1a0de780-4322-11eb-8f88-435f2c7c1d2b.png)

After:

![image](https://user-images.githubusercontent.com/52414509/102742079-0b273500-4322-11eb-90aa-a635c96a3d4e.png)
