### PR TITLE
fix svg scaling and overlay alignment

### DIFF
--- a/src/scss/yuzu/yuzu.scss
+++ b/src/scss/yuzu/yuzu.scss
@@ -48,6 +48,17 @@ a:hover {
   width: 55%;
 }
 
+// Fix switch svg scaling and image overlay alignment. 
+// (for bulma 0.9.0)
+.container {
+  flex-grow: 0;
+}
+
+.container.is-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 // Ensure that arrows consume the entire overlay's height.
 .glide__arrow {
   height: 100%;


### PR DESCRIPTION
This PR overwrites a few bulma CSS properties that were changed when we upgraded from `0.7.2` to `0.9.0` in https://github.com/yuzu-emu/yuzu-emu.github.io/pull/183

These changes allow for the Switch SVG to scale properly and the image overlay to be aligned with it.
Thanks to @Schplee for digging through the CSS changes. 

Tested changes locally but for some reason, netlify render doesn't work.