### PR TITLE
fix anchor jump issue

### DIFF
--- a/src/scss/yuzu/yuzu.scss
+++ b/src/scss/yuzu/yuzu.scss
@@ -147,3 +147,11 @@ pre > code {
 #view-package-listing-button {
   color: #363636;
 }
+
+// Fix anchor jumps (https://stackoverflow.com/a/28824157)
+:target::before {
+  content: "";
+  display: block;
+  height: 64px; /* fixed header height*/
+  margin: -64px 0 0; /* negative fixed header height */
+}


### PR DESCRIPTION
This fixes the issue of anchor links jumping too far due to the fixed header. 
* The solution was taken from <https://stackoverflow.com/a/28824157>
* Tested on Chrome 87 and Firefox 84
---
For creating anchor links, use Hugo in-built shortcodes `ref` or `relref`. For more details, see [here](https://gohugo.io/content-management/cross-references/) & [here](https://bwaycer.github.io/hugo_tutorial.hugo/extras/crossreferences/)

Fixes #239 