### PR TITLE
Quickstart updates due to driver support changes

### DIFF
--- a/site/content/help/quickstart/index.md
+++ b/site/content/help/quickstart/index.md
@@ -30,7 +30,7 @@ description: A guide designed to get you started with yuzu quickly.
 
 #### CPU: 
 
-Any x86_64 CPU with support for the FMA instruction set. 6 threads or more are recommended.
+Any x86_64 CPU with support for the FMA and AVX2 instruction set. 6 threads or more are recommended. Pre-Ryzen CPUs are strongly not recommended.
 
 - Minimum: Intel Core i5-4430 / AMD Ryzen 3 1200
 
@@ -38,28 +38,28 @@ Any x86_64 CPU with support for the FMA instruction set. 6 threads or more are r
 
 #### Dedicated graphics: 
 
-OpenGL 4.6 or Vulkan 1.1 compatible hardware and drivers are mandatory. Half-float support and 4GB of VRAM are recommended.
+OpenGL 4.6 or Vulkan 1.2 compatible hardware and drivers are mandatory. Half-float and VP9 decoding support, are recommended. At native resolutions, 4GB of video memory (VRAM) is strongly recommended. Vulkan 1.3 support is strongly recommended.
 
 - Minimum for Linux: NVIDIA GeForce GT 1030 2GB / AMD Radeon R7 240 2GB
 
 - Minimum for Windows: NVIDIA GeForce GT 1030 2GB / AMD Radeon RX 550 2GB
 
-- Recommended: NVIDIA GeForce GTX 1650 4GB / AMD Radeon RX Vega 56 8GB
+- Recommended: NVIDIA GeForce GTX 1660 6GB / AMD Radeon RX 6600 8GB
 
 #### Integrated graphics:
 
 Integrated graphics will produce very low performance. A dedicated GPU will produce better results on all scenarios.
 This is only for listing iGPU support.
 
-- Minimum for Linux: Intel HD 5300 / AMD Radeon R5 Graphics
+- Minimum for Linux: Intel HD 4400 / AMD Radeon Vega 3
 
-- Minimum for Windows: Intel HD Graphics 520 / AMD Radeon Vega 3
+- Minimum for Windows: Intel UHD Graphics 730 / AMD Radeon Vega 3
 
-- Recommended: Intel UHD Graphics 750 / AMD Radeon Vega 7
+- Recommended: Intel Xe Graphics / AMD Radeon Graphics (Vega 8)
 
 #### RAM: 
 
-Since an integrated GPU uses system RAM as its video memory (VRAM), our memory requirement in this configuration is higher.
+Since an integrated GPU uses system RAM as its VRAM, our memory requirement in this configuration is higher.
 
 - Minimum with dedicated graphics: 8GB
 
@@ -73,15 +73,15 @@ Since an integrated GPU uses system RAM as its video memory (VRAM), our memory r
 
 - Our recommended specifications don't guarantee perfect performance in most games, but rather strive to provide a cost effective recommendation while still considering performance.
 
-- Most games are playable on older Nvidia GPUs from the Fermi family (400 series) or later, but at least Pascal (1000 series) is strongly recommended.
+- Most games are playable on older Nvidia GPUs from the Fermi family (400 series) or later while using OpenGL, but at least Pascal (1000 series) is strongly recommended.
 
-- CPUs lacking the FMA instruction set will produce very poor results. Intel Core gen 3 series or older, AMD phenom II or older and all Pentium/Celeron/Atom CPUs will not produce optimal results.
+- CPUs lacking the FMA instruction set will produce very poor results. Intel Core gen 3 series or older, AMD phenom II or older and all Pentium/Celeron/Atom CPUs will not produce optimal results. AMD FX series CPUs will be very slow.
 
 - Mobile CPUs will not reach the same performance as their desktop counterparts due to thermal, power, and technical limitations. 
 
 - Old GCN 1.0 and GCN 2.0 Radeon GPUs on Linux require manually forcing the amdgpu kernel module.
 
-- **GPUs must support OpenGL 4.6 & OpenGL Compatibility profile, or Vulkan 1.1 (or higher).**<br>
+- **GPUs must support OpenGL 4.6 & OpenGL Compatibility profile, or Vulkan 1.2 (or higher).**<br>
 To find out if your GPU meets these requirements, visit https://opengl.gpuinfo.org or https://vulkan.gpuinfo.org/ and check your GPU details.<br>
 
 Sample Image:


### PR DESCRIPTION
Intel dropped support for pre-700 series GPUs, so Windows recommendations got updated.
Changed recommended dedicated GPUs after driver improvements and prices got better.
The previous minimum AMD GPU recommended for Linux was only included on CPUs that can't realistically run yuzu.
Expanded CPU support a bit to mention FX's abismal performance.
Added recommendations regarding VRAM, VP9 decoding.
Increased Vulkan requirement to 1.2.
And a bit more.