### PR TITLE
Download Page Rework

### DIFF
--- a/site/assets/scss/yuzu/yuzu.scss
+++ b/site/assets/scss/yuzu/yuzu.scss
@@ -135,12 +135,35 @@ pre > code {
   box-shadow: 0 1px 1px rgba(0,0,0,0.125);
 }
 
-// Workaround for browsers without JavaScript for the downloads page
-#install-view, #manual-package-view {
+#download-header {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+#download-buttons > a {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+@media screen and (min-width: 768px) {
+  #download-header {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  #download-buttons > a {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+#unsupported-platform-view {
   display: none;
 }
 
-.dl-button, #platform-unsupported {
+// Workaround for browsers without JavaScript for the downloads page
+#install-view, #manual-package-view {
   display: none;
 }
 

--- a/site/assets/scss/yuzu/yuzu.scss
+++ b/site/assets/scss/yuzu/yuzu.scss
@@ -98,6 +98,10 @@ a:hover {
   display: block !important;
 }
 
+.show-with-js {
+  display: none;
+}
+
 // Make text nicer to read in articles
 .section.content.pt-sm > p {
   text-align: justify;
@@ -142,14 +146,15 @@ pre > code {
 }
 
 #download-buttons > a {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 780px) {
   #download-header {
     flex-direction: row;
     text-align: left;
+    align-items: center;
   }
 
   #download-buttons > a {

--- a/site/content/downloads.md
+++ b/site/content/downloads.md
@@ -4,10 +4,8 @@ layout: "downloads"
 FullWidth: true
 ---
 
-<div class="columns is-desktop">
-<div class="column">
-<h2>Windows</h2>
-
+<div class="tab-content" id="tab-windows">
+<h2 class="hide-with-js mt-5">Windows Instructions</h2>
 <article class="message has-text-weight-semibold">
 <div class="message-body">
 <p style="color:cyan;margin-bottom: 0px;">yuzu requires the latest versions of Microsoft Visual C++. 
@@ -27,9 +25,8 @@ Intel and AMD users are strongly recommended to switch to Vulkan by going to `Em
 
 
 
-<div class="column">
-<h2>Linux</h2>
-
+<div class="tab-content" id="tab-linux">
+<h2 class="hide-with-js mt-5">Linux Instructions</h2>
 <article class="message has-text-weight-semibold">
 <div class="message-body">
 <p style="color:cyan;margin-bottom: 0px;">We have yuzu as an AppImage and Flatpak now! This relaxes dependency requirements for yuzu, as well as enabling it to run on a lot of older distributions.</p>
@@ -45,5 +42,4 @@ chmod a+x yuzu-*.AppImage
 ```
 
 Or with the GUI, right click the AppImage, click Properties, then Permissions, then click "Allow this file to run as a program". After that, double-click the AppImage to run it.
-</div>
 </div>

--- a/site/content/downloads.md
+++ b/site/content/downloads.md
@@ -4,29 +4,32 @@ layout: "downloads"
 FullWidth: true
 ---
 
-
-
-## Windows
+<div class="columns is-desktop">
+<div class="column">
+<h2>Windows</h2>
 
 <article class="message has-text-weight-semibold">
 <div class="message-body">
 <p style="color:cyan;margin-bottom: 0px;">yuzu requires the latest versions of Microsoft Visual C++. 
- Please download and install the dependency from below.</p>
+Please download and install the dependency from below.</p>
 <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">Download Microsoft Visual C++ 2022 here!</a>
 </div>
 </article>
 
-#### Windows Installer
+<h4>Windows Installer</h4>
 
 The installer will allow you to download your preferred release channel. 
 
 If you are a Patreon subscriber, the "Early Access" channel will be available to you, and will provide early access to exciting experimental changes on top of what is available in the main channel. Please follow our [Early Access guide](https://yuzu-emu.org/help/early-access/) for assistance linking your Patreon account.
 
 Intel and AMD users are strongly recommended to switch to Vulkan by going to `Emulation > Configure > Graphics > API`. Latest GPU drivers are recommended.
+</div>
 
-## Linux
 
-<link href="//cdn.jsdelivr.net/npm/font-logos@0.18/assets/font-logos.css" rel="stylesheet">
+
+<div class="column">
+<h2>Linux</h2>
+
 <article class="message has-text-weight-semibold">
 <div class="message-body">
 <p style="color:cyan;margin-bottom: 0px;">We have yuzu as an AppImage and Flatpak now! This relaxes dependency requirements for yuzu, as well as enabling it to run on a lot of older distributions.</p>
@@ -42,3 +45,5 @@ chmod a+x yuzu-*.AppImage
 ```
 
 Or with the GUI, right click the AppImage, click Properties, then Permissions, then click "Allow this file to run as a program". After that, double-click the AppImage to run it.
+</div>
+</div>

--- a/site/layouts/page/downloads.html
+++ b/site/layouts/page/downloads.html
@@ -19,7 +19,7 @@
             <article class="message is-danger" id="platform-unsupported">
                 <div class="message-body has-text-white my-5">
                     Currently, yuzu doesn't support your platform. If you are running Windows x64 or Linux x64 however,
-                    choose one of the options below.
+                    choose one of the options above.
                 </div>
             </article>
         </div>

--- a/site/layouts/page/downloads.html
+++ b/site/layouts/page/downloads.html
@@ -1,54 +1,60 @@
 {{ define "header" }}
-<section class="section">
-    <div class="container">
-        <h1 class="title">{{ .Title }}</h1>
-	<div class="content">
-	    {{ .Content }}
-	</div>
-</section>
+<link href="//cdn.jsdelivr.net/npm/font-logos@0.18/assets/font-logos.css" rel="stylesheet">
 
 <section class="section">
     <div class="container">
-        <div id="no-js-view">
-            Hi! We see that you have JavaScript disabled. We can't show you an
-            updated listing of the available packages for yuzu, nor alternative
-            installation methods, but here are a few links to get you started: <br />
-            <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/yuzu_install.exe">Windows x64 Installer</a><br />
-            <a href="https://github.com/yuzu-emu/yuzu-mainline/releases">Mainline releases on GitHub</a>
+        <div class="mb-6" id="download-header">
+            <div class="is-flex-grow-1">
+                <h1 class="title">{{ .Title }}</h1>
+            </div>
+            <div id="download-buttons">
+                <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/yuzu_install.exe" class="button dl-button is-medium is-success" id="dl-button-windows">
+                    <span class="icon mr-1"><i class="fab fa-windows"></i></span> Download for Windows x64
+                </a>
+                <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/liftinstall-31b3e7e.tar.xz" class="button dl-button is-medium is-success" id="dl-button-linux">
+                    <span class="icon mr-1"><i class="fab fa-linux"></i></span> Download for Linux x64
+                </a>
+            </div>
         </div>
-        <div id="install-view">
+
+        <div class="content">
+            {{ .Content }}
+        </div>
+    </div>
+</section>
+
+<section class="section pt-0">
+    <div class="container">
+        <div id="no-js-view">
+            <article class="message is-warn">
+                <div class="message-body has-text-white mb-6">
+                    Hi! We see that you have JavaScript disabled. You can still use the 
+                    above download links but we can't show you an updated listing of the available 
+                    packages for yuzu, nor alternative installation methods, but we recommend 
+                    viewing the 
+                    <a href="https://github.com/yuzu-emu/yuzu-mainline/releases">Mainline releases on GitHub</a>
+                </div>
+            </article>
+        </div>
+
+        <div id="unsupported-platform-view">
             <article class="message is-danger" id="platform-unsupported">
-                <div class="message-body has-text-white">
-                    yuzu doesn't support your platform. If you are running Windows x64 or Linux x64 however,
+                <div class="message-body has-text-white mb-6">
+                    Yuzu doesn't support your platform. If you are running Windows x64 or Linux x64 however,
                     choose one of the options below.
                 </div>
             </article>
-
-            <div class="buttons is-centered">
-                <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/yuzu_install.exe" class="button dl-button is-medium is-success" id="dl-button-windows">Download for Windows x64</a>
-                <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/liftinstall-31b3e7e.tar.xz" class="button dl-button is-medium is-success" id="dl-button-linux">Download for Linux x64</a>
-            </div>
-
-            <div class="buttons is-centered">
-                <!-- Show this when Flatpak/other primary installation methods are provided for Linux/Mac.
-                <a class="button">
-                    Other platforms
-                </a>
-                -->
-                <a class="button" id="view-package-listing-button">
-                    Manual Download
-                </a>
-            </div>
         </div>
+        
         <div class="columns" id="manual-package-view">
             <!-- Mainline -->
-            <div class="column">
-                <h3>Builds
-                    <span style='font-size: smaller; margin-left: 6px;'>
-                        Last release was
+            <div class="column content">
+                <h2>Builds
+                    <span class="tag is-info">
+                        Last release was &nbsp;
                         <span id='last-updated-mainline'></span>
                     </span>
-                </h3>
+                </h2>
 
                 <div id="downloads-mainline">
                 </div>
@@ -62,7 +68,7 @@
             </div>
         </div>
 	</div>
- </section>
+</section>
 
 <!-- Advertisement -->
 <section class="hero is-info">
@@ -76,6 +82,10 @@
 
 {{ define "scripts" }}
 <script type="text/javascript">
+    // Show JS relevant elements
+    document.getElementById("no-js-view").style.display = "none";
+    document.getElementById("manual-package-view").style.display = "block";
+
     function fetchReleases() {
         getRelease('mainline');
     }
@@ -84,10 +94,9 @@
 
     // Attempt autodetection of their operating system
     var userAgent = navigator.userAgent.toLowerCase();
-
-    var allPlatforms = ["windows", "mac", "linux"];
-
     var os = "Other";
+    const unsupportedPlatforms = ["Other", "Mac"]
+
     if (userAgent.indexOf("windows") !== -1) {
         os = "Windows";
     } else if (userAgent.indexOf("mac") !== -1 && userAgent.indexOf("mobile") === -1 && userAgent.indexOf("phone") === -1) {
@@ -96,36 +105,17 @@
         os = "Linux";
     }
 
-    // Configure the views for this platform
-    document.getElementById("no-js-view").style.display = "none";
-
-    var platformButton = document.getElementById("dl-button-" + os.toLowerCase());
-    if (platformButton !== null) {
-        platformButton.style.display = "block";
-    } else {
-        document.getElementById("platform-unsupported").style.display = "block";
+    switch (os) {
+        case "Windows":
+            document.getElementById("dl-button-linux").style.display = "none";
+            break;
+        case "Linux":
+            document.getElementById("dl-button-windows").style.display = "none";
+            break;
+        default:
+            document.getElementById("unsupported-platform-view").style.display = "block";
+            break
     }
-
-    // Installer is not available on all platforms
-    if (os === "Mac") {
-        document.getElementById("install-view").style.display = "none";
-        document.getElementById("manual-package-view").style.display = "flex";
-    } else {
-        document.getElementById("install-view").style.display = "block";
-        document.getElementById("manual-package-view").style.display = "none";
-    }
-    if (os === "Linux") {
-        document.getElementById("dl-button-linux").style.display = "block";
-        document.getElementById("dl-button-windows").style.display = "none";
-    } else if (os === "Windows") {
-        document.getElementById("dl-button-windows").style.display = "block";
-        document.getElementById("dl-button-linux").style.display = "none";
-    }
-
-    document.getElementById("view-package-listing-button").addEventListener("click", function() {
-        this.style.display = "none";
-        document.getElementById("manual-package-view").style.display = "flex";
-    });
 
 </script>
 {{ end }}

--- a/site/layouts/page/downloads.html
+++ b/site/layouts/page/downloads.html
@@ -3,10 +3,8 @@
 
 <section class="section">
     <div class="container">
-        <div class="mb-6" id="download-header">
-            <div class="is-flex-grow-1">
-                <h1 class="title">{{ .Title }}</h1>
-            </div>
+        <div class="mb-3" id="download-header">
+            <h1 class="title is-flex-grow-1 mb-0">{{ .Title }}</h1>
             <div id="download-buttons">
                 <a href="https://github.com/yuzu-emu/liftinstall/releases/download/1.9/yuzu_install.exe" class="button dl-button is-medium is-success" id="dl-button-windows">
                     <span class="icon mr-1"><i class="fab fa-windows"></i></span> Download for Windows x64
@@ -17,7 +15,39 @@
             </div>
         </div>
 
-        <div class="content">
+        <div id="unsupported-platform-view">
+            <article class="message is-danger" id="platform-unsupported">
+                <div class="message-body has-text-white my-5">
+                    Currently, yuzu doesn't support your platform. If you are running Windows x64 or Linux x64 however,
+                    choose one of the options below.
+                </div>
+            </article>
+        </div>
+
+        <div class="show-with-js">
+            <div class="tabs " id="platform-switcher">
+                <ul>
+                    <li data-target="tab-windows">
+                        <a>
+                            <span class="icon is-small"><i class="fab fa-windows"></i></span>
+                            <span>Windows</span>
+                        </a>
+                    </li>
+                    <li data-target="tab-linux">
+                        <a>
+                            <span class="icon is-small"><i class="fab fa-linux"></i></span>
+                            <span>Linux</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="content">
+                <h2>Instructions</h2>
+            </div>
+        </div>
+
+        <div class="content" id="platform-instructions">
             {{ .Content }}
         </div>
     </div>
@@ -25,7 +55,9 @@
 
 <section class="section pt-0">
     <div class="container">
-        <div id="no-js-view">
+        <div class="hide-with-js content">
+            <h2>Builds</h2>
+
             <article class="message is-warn">
                 <div class="message-body has-text-white mb-6">
                     Hi! We see that you have JavaScript disabled. You can still use the 
@@ -36,19 +68,10 @@
                 </div>
             </article>
         </div>
-
-        <div id="unsupported-platform-view">
-            <article class="message is-danger" id="platform-unsupported">
-                <div class="message-body has-text-white mb-6">
-                    Yuzu doesn't support your platform. If you are running Windows x64 or Linux x64 however,
-                    choose one of the options below.
-                </div>
-            </article>
-        </div>
         
-        <div class="columns" id="manual-package-view">
+        <div class="show-with-js" id="package-view">
             <!-- Mainline -->
-            <div class="column content">
+            <div class="content">
                 <h2>Builds
                     <span class="tag is-info">
                         Last release was &nbsp;
@@ -82,39 +105,78 @@
 
 {{ define "scripts" }}
 <script type="text/javascript">
-    // Show JS relevant elements
-    document.getElementById("no-js-view").style.display = "none";
-    document.getElementById("manual-package-view").style.display = "block";
+    const setTabActive = (targetId) => {
+        document.querySelectorAll(".content .tab-content")
+            .forEach(element => element.style.display = "none");
 
-    function fetchReleases() {
-        getRelease('mainline');
+        document.querySelectorAll(`#${targetId}`)    
+            .forEach(element => element.style.display = "block");
+
+        document.querySelectorAll(".tabs li")    
+            .forEach(element => element.classList.remove('is-active'));
+
+        document.querySelectorAll(`[data-target="${targetId}"]`)    
+            .forEach(element => element.classList.add('is-active'));
     }
 
-    fetchReleases();
+    const getOSGuess = () => {
+        const userAgent = navigator.userAgent.toLowerCase();
+
+        if (userAgent.includes("windows")) {
+            return "Windows";
+        } else if (
+            userAgent.includes("mac") && 
+            !userAgent.includes("mobile") && 
+            !userAgent.includes("phone")
+        ) {
+            return "Mac";
+        } else if (
+            userAgent.includes("linux") && 
+            userAgent.includes("android")
+        ) {
+            return "Linux";
+        }
+
+        return "Other";
+    }
+
+    const setupListeners = () => {
+        document.querySelectorAll(".tabs li")
+            .forEach(element => 
+                element.addEventListener('click', (event) => {
+                    setTabActive(element.dataset.target);
+                })
+            );
+    }
+
+    getRelease('mainline');
+
+    // Show JS relevant elements
+    document.querySelectorAll(".hide-with-js")
+        .forEach(element => element.style.display = "none");
+
+    document.querySelectorAll(".show-with-js")
+        .forEach(element => element.style.display = "block");
+    
+    document.querySelectorAll(".content .tab-content")
+        .forEach(element => element.style.display = "none");
 
     // Attempt autodetection of their operating system
-    var userAgent = navigator.userAgent.toLowerCase();
-    var os = "Other";
-
-    if (userAgent.indexOf("windows") !== -1) {
-        os = "Windows";
-    } else if (userAgent.indexOf("mac") !== -1 && userAgent.indexOf("mobile") === -1 && userAgent.indexOf("phone") === -1) {
-        os = "Mac";
-    } else if (userAgent.indexOf("linux") !== -1 && userAgent.indexOf("android") === -1) {
-        os = "Linux";
-    }
-
-    switch (os) {
+    switch (getOSGuess()) {
         case "Windows":
             document.getElementById("dl-button-linux").style.display = "none";
+            setTabActive('tab-windows');
             break;
         case "Linux":
             document.getElementById("dl-button-windows").style.display = "none";
+            setTabActive('tab-linux');
             break;
         default:
             document.getElementById("unsupported-platform-view").style.display = "block";
+            setTabActive('tab-windows');
             break
     }
 
+    window.addEventListener('DOMContentLoaded', setupListeners);
 </script>
 {{ end }}

--- a/site/layouts/page/downloads.html
+++ b/site/layouts/page/downloads.html
@@ -95,7 +95,6 @@
     // Attempt autodetection of their operating system
     var userAgent = navigator.userAgent.toLowerCase();
     var os = "Other";
-    const unsupportedPlatforms = ["Other", "Mac"]
 
     if (userAgent.indexOf("windows") !== -1) {
         os = "Windows";


### PR DESCRIPTION
- Removes extra click for builds
- Moves download to very top, and on larger screens, moves it to the right
- Uses tabs for the info dump to let people get to builds faster
- Tidies up some scripts
- Shows links for both if platform is unsupported or js is diabled.

### 📸 Screenshots

#### Normal
![Screenshot 2023-01-31 at 22-36-32 Downloads · yuzu](https://user-images.githubusercontent.com/7660486/215939508-676ccf99-444d-4a29-adc4-13c745fd9f0a.png)

#### Smaller Screen (Unsupported Platform)
![Screenshot 2023-01-31 at 22-41-58 Downloads · yuzu](https://user-images.githubusercontent.com/7660486/215939873-35524fc5-e9ce-42a0-9d32-9244617fbe7c.png)

#### Mobile
![Screenshot 2023-01-31 at 22-42-08 Downloads · yuzu](https://user-images.githubusercontent.com/7660486/215939889-92e1262b-d369-4bbb-810a-044388474c37.png)

#### No JS
![Screenshot 2023-01-31 at 22-33-47 Downloads · yuzu](https://user-images.githubusercontent.com/7660486/215939916-c4cf42c0-d511-4319-a2aa-5e0f49bfe882.png)
